### PR TITLE
Fixed 'ping'-'pong' behavior/relation documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ A noop packet. Used primarily to force a poll cycle when an incoming websocket c
 
 ##### example
 1. client connects through new transport
-2. client sends ```2probe```
-3. server receives and sends ```3probe```
+2. client sends ```2probe``` (ping)
+3. server receives and sends ```3``` (pong)
 4. client receives and sends ```5```
 5. server flushes and closes old transport and switches to new.
 

--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ Request the close of this transport but does not shutdown the connection itself.
 
 #### 2 ping
 
-Sent by the client. Server should answer with a pong packet containing the same data
+Sent by the client. Server should respond with packet of type 'pong'.
 
-example
-1. client sends: ```2probe```
-2. server sends: ```3probe```
+example  
+1. client sends: ```2probe```  
+2. server sends: ```3```
 
 #### 3 pong
 


### PR DESCRIPTION
Server 'pong' packet should consist only of the packet type and MUST NOT return the data that the client sent with the 'ping' packet.

Allowing server to repeat client data will open must space for security concerns and/or possible memory leaks. Plus this is totally redundant as it consumes more time (tied with latency) from the server.
