### PR TITLE
Fix test `ignores websocket connection with same sid after upgrade`

### DIFF
--- a/test-suite/test-suite.js
+++ b/test-suite/test-suite.js
@@ -542,7 +542,7 @@ describe("Engine.IO protocol", () => {
       expect(data).to.eql("4hello");
     });
 
-    it("ignores WebSocket connection with same sid after upgrade", async () => {
+    it("should ignore WebSocket connection with same sid after upgrade", async () => {
       const sid = await initLongPollingSession();
 
       const socket = new WebSocket(
@@ -550,14 +550,21 @@ describe("Engine.IO protocol", () => {
       );
 
       await waitFor(socket, "open");
+
       socket.send("2probe");
+      let res = await waitFor(socket, "message");
+      expect(res.data).to.eql("3probe");
+
       socket.send("5");
+
+      res = await waitFor(socket, "message");
+      expect(res.data).to.eql("6");
 
       const socket2 = new WebSocket(
         `${WS_URL}/engine.io/?EIO=4&transport=websocket&sid=${sid}`
       );
 
-      await waitFor(socket2, "error");
+      await waitFor(socket2, "close");
 
       socket.send("4hello");
 


### PR DESCRIPTION
This pull request resolve [this issue](https://github.com/socketio/socket.io-protocol/issues/29)

There is a difference for the same test between this test-suite and the one from socket.io-protocol. 
Even the official engine.io implementation could not pass the original test with this example :

```js
const engine = require('engine.io');
const server = engine.listen(3000, {
    pingInterval: 300,
    pingTimeout: 200
});

server.on('connection', socket => {
    socket.on('message', data => {
        socket.send(data);
    });
});
````