### PR TITLE
fix: `ignores WebSocket connection with same sid after upgrade`

### DIFF
--- a/test-suite/test-suite.js
+++ b/test-suite/test-suite.js
@@ -557,7 +557,7 @@ describe("Engine.IO protocol", () => {
         `${WS_URL}/engine.io/?EIO=4&transport=websocket&sid=${sid}`
       );
 
-      await waitFor(socket2, "error");
+      await waitFor(socket2, "close");
 
       socket.send("4hello");
 


### PR DESCRIPTION
The second websocket created after an upgrade should gracefully close and not throw an error as specified in the official implementation. Moreover in the same test for the [`socket.io` test suite](https://github.com/socketio/socket.io-protocol/blob/5924e987b6a877e3c8b5997956bd1469912453a3/test-suite/test-suite.js#L386) the implementation wait for the second websocket to gracefully close.

Here is an example of engine.io server which fails at validating this test:
```ts
const engine = require('engine.io');
const server = engine.listen(3000, {
    pingInterval: 300,
    pingTimeout: 200
});

server.on('connection', socket => {
    socket.on('message', data => {
        socket.send(data);
    });
});
```

It would be nice to be able to use a separate engine.io test suite in CI for our rust server implementation [socketioxide](https://github.com/totodore/socketioxide).

Closes https://github.com/socketio/socket.io-protocol/issues/29
Closes https://github.com/Totodore/socketioxide/issues/15