### PR TITLE
fix: Payload encoding example with binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ Please note that we are not counting bytes, but characters, hence 2 (1 + 1) inst
 is encoded to:
 
 ```
-buffer <00 04 ff 34 e2 82 ac 01 04 ff 01 02 03 04>
+buffer <00 04 ff 34 e2 82 ac 01 05 ff 04 01 02 03 04>
 
 with:
 
@@ -374,8 +374,9 @@ ff              => separator
 34              => "message" packet type ("4")
 e2 82 ac        => "€"
 01              => binary header
-04              => buffer length in bytes
+05              => buffer length in bytes
 ff              => separator
+04              => "message" packet type (4)
 01 02 03 04     => buffer content
 ```
 


### PR DESCRIPTION
I noticed that only the protocol 4 had typing support and I wanted to implement the protocol 3 client myself with typescript and was testing all things needed for a fully featured protocol 3 client. During this time, I noticed that the example of the payload with binary message, with binary output, is incorrectly documented as it is missing the type byte in the Buffer output. Running the example with `engine.io-parser@2.2.1` (last supported parser for protocol 3) to test the actual output.

```
const parser = require('engine.io-parser');

parser.encodePayload([
  {
    type: 'message',
    data: '€',
  },
  {
    type: 'message',
    data: Buffer.from([1, 2, 3, 4]),
  },
], false, console.log);
```

On the console, the following gets printed

```
<Buffer 00 04 ff 34 e2 82 ac 01 05 ff 04 01 02 03 04>
```

In the protocol document, the example shows an output of 
```
buffer <00 04 ff 34 e2 82 ac 01 04 ff 01 02 03 04>
```

This commit aims to fix this discrepancy in the example.